### PR TITLE
Add NixOS script to run the parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,13 @@ Browser for plasmids search.
 
 **Data sources**: browser engine store data from [Addgene](https://www.addgene.org/), [Registry of Standard Biological Parts](http://parts.igem.org/Main_Page), and other sources.  
 
-**Technological Stack**: Python
+**Technological Stack**: Python, PostgreSQL, Django, Flask, FastAPI, ...   
 
 
+# Linux (Nix or NixOs)
+
+To run the script:
+```
+nix-shell
+python 'Addgene parser.py'
+```

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,11 @@
+{ pkgs ? import <nixpkgs> {} }:
+let
+  my-python-packages = ps: with ps; [
+    pandas
+    requests
+    beautifulsoup4
+    numpy    
+    # other python packages
+  ];
+  my-python = pkgs.python3.withPackages my-python-packages;
+in my-python.env


### PR DESCRIPTION
The PR adds `shell.nix` file that contains description of Python environment with libraries required to execute the parser without global installation.